### PR TITLE
Fixed data loss issue in time-based querying and added ‘quarter’ as a new parameter option.

### DIFF
--- a/redash_pandas/redash.py
+++ b/redash_pandas/redash.py
@@ -268,14 +268,14 @@ class Redash:
 
         start_dates = pd.date_range(start=start_date, end=end_date, freq=interval)
         # create offset of interval_multiple
-        std_start_date = pd.to_datetime(start_date)
+        user_input_start_date = pd.to_datetime(start_date)
 
         if start_dates.empty:
             print('Too short period!')
-            start_dates = [std_start_date] 
+            start_dates = [user_input_start_date] 
             end_dates = [pd.to_datetime(end_date)]
-        elif start_dates[0] != std_start_date:
-            start_dates = [std_start_date] + start_dates[::interval_multiple].tolist()
+        elif start_dates[0] != user_input_start_date:
+            start_dates = [user_input_start_date] + start_dates[::interval_multiple].tolist()
             end_dates = start_dates[1:] + [pd.to_datetime(end_date)]
         else:
             start_dates = start_dates[::interval_multiple]

--- a/redash_pandas/redash.py
+++ b/redash_pandas/redash.py
@@ -217,7 +217,7 @@ class Redash:
         query_id: int,
         start_date: str,  # like '2024-01-01'
         end_date: str,  # like '2024-01-31'
-        interval: Literal["day", "week", "month", "year"],
+        interval: Literal["day", "week", "month", "quarter", "year"],
         params: Optional[dict] = None,
         interval_multiple: int = 1,
         max_age: int = 0,

--- a/redash_pandas/redash.py
+++ b/redash_pandas/redash.py
@@ -271,7 +271,7 @@ class Redash:
         user_input_start_date = pd.to_datetime(start_date)
 
         if start_dates.empty:
-            print('Too short period!')
+            print("The entered time range is too short, fetch the data as much as possible for you.")
             start_dates = [user_input_start_date] 
             end_dates = [pd.to_datetime(end_date)]
         elif start_dates[0] != user_input_start_date:


### PR DESCRIPTION
--Bug Fix: Resolved an issue where data retrieval could be incomplete if start_date was not aligned with standard rule dates (e.g., beginning of the year or quarter).

example:
```
df_example  = redash.period_limited_query(7399
                                     , start_date='2022-02-18 00:00:00'
                                     , end_date='2022-03-31 23:59:59'
                                     , interval='month'
                                     , interval_multiple = 1)
```

 

> In the previous implementation, when calling the function as described, data for the period from 2022-02-18 to 2022-02-28 would be lost, and only data from 2022-03-01 to 2022-03-31 could be retrieved. After the fix, the query is now split into two segments, ensuring the complete retrieval of data from 2022-02-18 to 2022-03-31.
（上記の関数呼び出し方法において、以前は2022-02-18から2022-02-28の期間のデータが欠落し、2022-03-01から2022-03-31の期間のみ取得可能でした。修正後は、上記の2つの期間に分けてデータを取得し、2022-02-18から2022-03-31までの完全なデータを取得できるようになりました。）



--Enhancement: Added quarter as a new optional interval parameter for the period_limited_query() function, allowing for querying data based on quarterly intervals.